### PR TITLE
Fixed the gear script & a bunch of other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Welcome to Malbryn's Mission Framework. This framework was made for my Arma 3 sc
 
 ### MF_AI
  - AI task scripts (Creep, Hunt, Rush)
-  - Global AI skill settings
+ - Global AI skill settings
 
 ### MF_Cfg
  - Custom end mission stats

--- a/mission_framework/root/MF_Cfg/cba_xeh/preInit.sqf
+++ b/mission_framework/root/MF_Cfg/cba_xeh/preInit.sqf
@@ -42,7 +42,9 @@ MF_var_sc_enabled = false;
 MF_var_nd_ending_enabled = false;
 MF_var_snowfall_enabled = false;
 MF_var_wave_respawn_enabled = false;
+MF_var_wave_respawn_count = -1;
 MF_var_tasks = [];
 
 
+// Compile the AI skills
 call compile preprocessFileLineNumbers "mission_framework\config\ai_skill\ai_skill.sqf";

--- a/mission_framework/root/MF_Logistics/reinsert/fncInit.sqf
+++ b/mission_framework/root/MF_Logistics/reinsert/fncInit.sqf
@@ -1,11 +1,17 @@
-MF_fnc_addParachute = compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\halo\fn_addParachute.sqf";
+MF_fnc_addParachute =
+	compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\halo\fn_addParachute.sqf";
 
-MF_fnc_halodrop = compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\halo\fn_haloDrop.sqf";
+MF_fnc_halodrop =
+	compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\halo\fn_haloDrop.sqf";
 
-MF_fnc_tpToMrv = compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\mrv\fn_tpToMrv.sqf";
+MF_fnc_tpToMrv =
+	compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\mrv\fn_tpToMrv.sqf";
 
-MF_fnc_deployRp = compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\rally_point\fn_deployRp.sqf";
+MF_fnc_deployRp =
+	compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\rally_point\fn_deployRp.sqf";
 
-MF_fnc_tpToRp = compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\rally_point\fn_tpToRp.sqf";
+MF_fnc_tpToRp =
+	compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\rally_point\fn_tpToRp.sqf";
 
-MF_fnc_removeRp = compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\rally_point\fn_removeRp.sqf";
+MF_fnc_removeRp =
+	compile preprocessFileLineNumbers "mission_framework\root\MF_Logistics\reinsert\rally_point\fn_removeRp.sqf";

--- a/mission_framework/root/MF_Logistics/reinsert/init.sqf
+++ b/mission_framework/root/MF_Logistics/reinsert/init.sqf
@@ -4,6 +4,7 @@
  *
  * Description:
  * Adds different options to an object ("TP pole") for reinsertion
+ * Also adds the rally point menu to the squad leader
  *
  * Arguments:
  * _this select 0: OBJECT - Object that acts as a TP pole
@@ -17,6 +18,8 @@
  */
 
 if (hasInterface) then {
+    if (isNull tpPole) exitWith { systemChat "[MF ERROR] Teleport pole does not exist!" };
+
     // Option #1 - Paradrop
     if (MF_var_use_halo) then {
         tpPole addAction ["Reinsert - Paradrop", {
@@ -37,4 +40,10 @@ if (hasInterface) then {
             [] spawn MF_fnc_tpToRp;
         }];
     };
+};
+
+
+// Assigning the RP menu to the squad leaders
+if (hasInterface && MF_var_use_rp && ((leader group player) == player)) then {
+    [] call MF_fnc_addRpMenu;
 };

--- a/mission_framework/root/MF_Player/gear/fn_setGear.sqf
+++ b/mission_framework/root/MF_Player/gear/fn_setGear.sqf
@@ -59,6 +59,6 @@ if !(count _gear == 0) then {
 diag_log "[MF LOG] Loadout applied. Saving...";
 
 // Save the current loadout
-player setVariable ["MF_var_current_loadout", _role];
+_unit setVariable ["MF_var_current_loadout", _role, true];
 
-diag_log format ["[MF LOG] Loadout saved: %1. Gear script done.", player getVariable "MF_var_current_loadout"];
+diag_log format ["[MF LOG] Loadout saved: %1. Gear script done.", _unit getVariable "MF_var_current_loadout"];

--- a/mission_framework/root/MF_Player/init_player/fn_assignCO.sqf
+++ b/mission_framework/root/MF_Player/init_player/fn_assignCO.sqf
@@ -19,4 +19,4 @@
 
 params ["_unit", ["_check", true]];
 
-_unit setVariable ["MF_var_is_CO", _check];
+_unit setVariable ["MF_var_is_CO", _check, true];

--- a/mission_framework/root/MF_Player/init_player/fn_initPlayer.sqf
+++ b/mission_framework/root/MF_Player/init_player/fn_initPlayer.sqf
@@ -6,7 +6,7 @@
  * Sets up the player entity
  *
  * Arguments:
- * _this select 0: OBJECT - The unit (Optional, default: player)
+ * _this select 0: OBJECT - The unit
  * _this select 1: STRING - Role of the unit, see: gear script
  * _this select 2: BOOLEAN - True if the unit is a command element (the CO can end the mission and/or call in supply drops)
  *                           (Optional, default: false)
@@ -16,33 +16,33 @@
  * void
  *
  * Example:
- * [this, "PLTHQ", true, "YELLOW"] spawn MF_fnc_initPlayer
+ * [this, "PLTHQ", true, "YELLOW"] call MF_fnc_initPlayer
  *
  */
 
-if (!hasInterface) exitWith {};
-
-params [["_unit", player], "_role", ["_isCO", false], ["_colour", "MAIN"]];
+params ["_unit", "_role", ["_isCO", false], ["_colour", "MAIN"]];
 
 diag_log format ["[MF LOG] Initialising unit: %1 (Local: %2)", _unit, local _unit];
 
 // Fixing locality issues
-waitUntil {!isNull _unit};
-if (!local _unit) exitWith {};
+if !(local _unit) exitWith {};
 
 
 // Gear script
 [_unit, _role] call MF_fnc_setGear;
 
 
-// Command element (can call retreat and call in supply drops)
-[_unit, _isCO] call MF_fnc_assignCO;
+// Command element (can call retreat, call respawn and call in supply drops)
+if (_isCO) then {
+    [_unit, _isCO] call MF_fnc_assignCO;
+};
 
 
 // Assign team colour
 _unit assignTeam _colour;
 
 
+// ACE player variables
 if ((roleDescription _unit) find "Medic" >= 0) then {
     _unit setVariable ["ACE_medical_medicClass", 1, true];
 } else {
@@ -50,13 +50,7 @@ if ((roleDescription _unit) find "Medic" >= 0) then {
 };
 
 if ((roleDescription _unit) find "Pilot" >= 0) then {
-    _unit setVariable ["ACE_GForceCoef", 0.5];
+    _unit setVariable ["ACE_GForceCoef", 0.5, true];
 } else {
-    _unit setVariable ["ACE_GForceCoef", 1.0];
-};
-
-
-// Assign group leader rally point menu
-if ((leader group _unit) == _unit) then {
-    [] call MF_fnc_addRpMenu;
+    _unit setVariable ["ACE_GForceCoef", 1.0, true];
 };

--- a/onPlayerKilled.sqf
+++ b/onPlayerKilled.sqf
@@ -7,7 +7,6 @@ private _killer = player getVariable ["ace_medical_lastDamageSource", objNull];
 private _nameKiller = name _killer;
 private _nameKilled = name player;
 
-
 if (side _killer == playerSide) then {
     [_nameKilled, _nameKiller] remoteExec ["MF_fnc_friendlyFireMessage", 0];
 };
@@ -29,13 +28,19 @@ uiSleep 5;
 
 
 // Init the spectator mode along with some other stuff
-if (MF_var_respawn_tickets == 0) then {
+if (MF_var_respawn_tickets == 0 ||  MF_var_wave_respawn_count == 0) then {
 
     setPlayerRespawnTime 999999;
 
-    ["Initialize", [player, [], false, false, true, false, false, false, false, true]] call BIS_fnc_EGSpectator;
+    ["Initialize", [player, [], false, true, true, false, true, false, false, true]] call BIS_fnc_EGSpectator;
 
-    ["Warning", ["No more respawns ramaining!"]] call BIS_fnc_showNotification;
+    if (MF_var_respawn_tickets == 0) then {
+        ["Warning", ["You have no more respawn tickets!"]] call BIS_fnc_showNotification;
+    };
+
+    if (MF_var_wave_respawn_count == 0) then {
+        ["Warning", ["No more reinforcement wave ramaining!"]] call BIS_fnc_showNotification;
+    };
 
     cutText  ["", "BLACK IN",  3, true];
     "dynamicBlur" ppEffectAdjust [0];
@@ -43,30 +48,42 @@ if (MF_var_respawn_tickets == 0) then {
 
     // Transfer SL modules to the next player in command (Squad Rally Point)
     if (player == leader group player && MF_var_use_rp) then {
-        private _partGroup = _partGroup - [(leader group player)];
-        private _target = _partGroup select (_partGroup findIf {alive _x});
+        private _partGroup = units group player;
+        private _target = objNull;
+        _partGroup = _partGroup - [(leader group player)];
+        _target = _partGroup select (_partGroup findIf {alive _x});
 
-        [] remoteExec ["MF_fnc_addRpMenu", _target];
+        if !(_target getVariable "MF_var_is_CO") then {
+            [] remoteExec ["MF_fnc_addRpMenu", _target];
+        };
     };
 
     // Transfer CO modules to the next player in command (Supply Drop, Scenario End Control)
     if (player getVariable "MF_var_is_CO" && MF_var_use_supply_drop) then {
-        private _partGroup = _partGroup - [(leader group player)];
-        private _target = _partGroup select (_partGroup findIf {alive _x});
+        private _partGroup = units group player;
+        private _target = objNull;
+        _partGroup = _partGroup - [(leader group player)];
+        _target = _partGroup select (_partGroup findIf {alive _x});
 
-        [] remoteExec ["MF_fnc_addSupplyDropMenu", _target];
+        if !(_target getVariable "MF_var_is_CO") then {
+            [] remoteExec ["MF_fnc_addSupplyDropMenu", _target];
+        };
     };
 
     if (player getVariable "MF_var_is_CO" && MF_var_sc_enabled) then {
-        private _partGroup = _partGroup - [(leader group player)];
-        private _target = _partGroup select (_partGroup findIf {alive _x});
+        private _partGroup = units group player;
+        private _target = objNull;
+        _partGroup = _partGroup - [(leader group player)];
+        _target = _partGroup select (_partGroup findIf {alive _x});
 
-        [] remoteExec ["MF_fnc_addScenarioEndControl", _target];
+        if !(_target getVariable "MF_var_is_CO") then {
+            [] remoteExec ["MF_fnc_addScenarioEndControl", _target];
+        };
     };
 
 } else {
 
-    ["Initialize", [player, [], false, false, true, false, false, false, false, true]] call BIS_fnc_EGSpectator;
+    ["Initialize", [player, [], false, false, true, false, true, false, false, true]] call BIS_fnc_EGSpectator;
 
     cutText  ["", "BLACK IN",  3, true];
     "dynamicBlur" ppEffectAdjust [0];
@@ -77,20 +94,12 @@ if (MF_var_respawn_tickets == 0) then {
 // If the CO dies during a wave respawn mission, the ability to call in reinforcements
 // will be transferred to the next person in command
 if (player getVariable "MF_var_is_CO" && MF_var_wave_respawn_enabled) then {
-    private _partGroup = _partGroup - [(leader group player)];
-    private _target = _partGroup select (_partGroup findIf {alive _x});
+    private _partGroup = units group player;
+    private _target = objNull;
+    _partGroup = _partGroup - [(leader group player)];
+    _target = _partGroup select (_partGroup findIf {alive _x});
 
-    [] remoteExec ["MF_fnc_addCallRespawnMenu", _target];
-};
-
-
-// Notify the player if there won@t be any respawn wave left
-if (MF_var_wave_respawn_count == 0) then {
-    ["Warning", ["No more reinforcement wave ramaining!"]] call BIS_fnc_showNotification;
-};
-
-
-// Stop the snow script if enabled
-if (MF_var_snowfall_enabled) then {
-    missionNameSpace setVariable ["MF_var_snowfall_start", false];
+    if !(_target getVariable "MF_var_is_CO") then {
+        [] remoteExec ["MF_fnc_addCallRespawnMenu", _target];
+    };
 };

--- a/onPlayerRespawn.sqf
+++ b/onPlayerRespawn.sqf
@@ -9,21 +9,19 @@ cutText  ["", "BLACK IN", 5, true];
 "dynamicBlur" ppEffectAdjust [0.0];
 "dynamicBlur" ppEffectCommit 3;
 
+
 // Close the spectator mode
 ["Terminate"] call BIS_fnc_EGSpectator;
 
+
 // Exit the spectator voice channel
 [player, false] call TFAR_fnc_forceSpectator;
+
 
 // Load the player's loadout
 private _loadout = player getVariable "MF_var_current_loadout";
 [player, _loadout] call MF_fnc_setGear;
 
-// Start the snow script if enabled
-if (MF_var_snowfall_enabled) then {
-    missionNameSpace setVariable ["MF_var_snowfall_start", true];
-    [] spawn MF_fnc_startSnowfall;
-};
 
 // Remaining respawn tickets
 if (MF_var_respawn_tickets == -1) exitWith {};


### PR DESCRIPTION
ADDED
 - Default wave respawn count to preInit (-1)
 - Debug message if the TP pole is not set up

REMOVED

FIXED
 - Typos & formatting
 - Gear script changes (fixed the server-client stuff, the loadout variable is now assigned to the unit instead of the player)
 - Fixed the CO abilities transfer in onPlayerKilled as _target and _partGorup were not defined initially

CHANGED
 - Add rally point menu runs in reinsert init instead of player init
 - Player variables are now public
 - Spectator camera now has camera modes enabled. If there's no more respawns available, free camera is enabled
 - The CO and SL abilities will transfer if there is no more respawn waves (it was linked to player respawn tickets only before)
 - Snow script won't be toggled when player dies & respawns (to save the player's setting if they turnt it off)