### PR TITLE
Added new admin chat command

### DIFF
--- a/mission_framework/root/MF_Admin/admin_menu/registerAdminCommand.sqf
+++ b/mission_framework/root/MF_Admin/admin_menu/registerAdminCommand.sqf
@@ -3,8 +3,7 @@
  * Malbryn
  *
  * Description:
- * Registers a chat command which can be used to reassign the admin commands.
- * This can be used if the admin logs in after mission init.
+ * Registers chat commands that can be used by the logged-in admin.
  *
  * Arguments:
  * -
@@ -18,8 +17,17 @@
  */
 
 if (hasInterface) then {
+    // Adds admin menu to the self-nteraction options
+    // Use this if the admin logs in after mission init
     ["addAdminMenu", {
         [] execVM "mission_framework\root\MF_Admin\init.sqf";
         systemChat "[MF INFO] Adding admin menu...";
+    }, "admin"] call CBA_fnc_registerChatCommand;
+
+    // Adds an option to terminate the mission
+    // Use this if the admin is dead and the mission breaks
+    ["terminateMission", {
+        ["MissionTerminated", false] remoteExec ["MF_fnc_endMission", 2];
+        systemChat "[MF INFO] Terminating mission...";
     }, "admin"] call CBA_fnc_registerChatCommand;
 };


### PR DESCRIPTION
ADDED
 - New chat command for admins - terminateMission (if the admin and mission creators are dead and the mission breaks, the admin can terminate the mission still)

REMOVED

FIXED

CHANGED