### PR TITLE
Add TP destination function to Reinsertion

### DIFF
--- a/mission_framework/core/reinsertion/XEH_PREP.hpp
+++ b/mission_framework/core/reinsertion/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 PREP(addHABMenu);
 PREP(addParachute);
 PREP(addRPMenu);
+PREP(createTPDestination);
 PREP(deployHAB);
 PREP(deployRP);
 PREP(haloDrop);

--- a/mission_framework/core/reinsertion/XEH_PostInit.sqf
+++ b/mission_framework/core/reinsertion/XEH_PostInit.sqf
@@ -11,5 +11,11 @@ if (hasInterface) then {
         call FUNC(addHABMenu);
     }] call CFUNC(addEventHandler);
 
+    [QGVAR(createTPDestination), {
+        params ["_name", "_pos"];
+
+        [_name, _pos] call FUNC(createTPDestination);
+    }] call CFUNC(addEventHandler);
+
     call FUNC(initPole);
 };

--- a/mission_framework/core/reinsertion/functions/fnc_addRPMenu.sqf
+++ b/mission_framework/core/reinsertion/functions/fnc_addRPMenu.sqf
@@ -20,7 +20,7 @@
 if !(hasInterface) exitWith {};
 
 // Create parent category
-private  _menu = ['Rally Point', 'Rally Point', '\a3\ui_f\data\GUI\Cfg\Hints\icon_text\b_inf_ca.paa', {}, {!visibleMap && isNull objectParent player}] call AFUNC(interact_menu,createAction);
+private _menu = ['Rally Point', 'Rally Point', '\a3\ui_f\data\GUI\Cfg\Hints\icon_text\b_inf_ca.paa', {}, {!visibleMap && isNull objectParent player}] call AFUNC(interact_menu,createAction);
 
 [player, 1, ["ACE_SelfActions"], _menu] call AFUNC(interact_menu,addActionToObject);
 

--- a/mission_framework/core/reinsertion/functions/fnc_createTPDestination.sqf
+++ b/mission_framework/core/reinsertion/functions/fnc_createTPDestination.sqf
@@ -1,0 +1,64 @@
+#include "script_component.hpp"
+
+/*
+    Author:
+        Malbryn
+
+    Description:
+        Creates the RP menu for the group leader.
+        Use the "createTPDestination" EH on the server to sync it with JIP players.
+        (Example:
+            [
+                "MF_reinsertion_createTPDestination",
+                ["Kavala City Centre", getMarkerPos "marker_kavala"]
+            ] call CBA_fnc_globalEventJIP
+        )
+
+    Arguments:
+        0: STRING - Name of the destination that appears in the scroll wheel menu
+        1: ARRAY - Coordinates of the destination
+
+    Example:
+        ["Kavala City Centre", getMarkerPos "marker_kavala"] call MF_reinsertion_fnc_createTPDestination
+
+    Returns:
+        BOOLEAN
+*/
+
+if !(hasInterface) exitWith {};
+
+params ["_name", "_pos"];
+
+private _tpPoles = [];
+private _pole = objNull;
+
+GVAR(TPPoles) apply {
+    _pole = call compile _x;
+    _tpPoles pushBack _pole;
+};
+
+if (count _tpPoles == 0) exitWith {
+    MSG("WARNING","(Reinsertion) The teleport pole array is empty");
+    false
+};
+
+_tpPoles apply {
+    if (isNull _x) exitWith {
+        MSG_1("ERROR","(Reinsertion) Teleport pole object (%1) does not exist",_x);
+    };
+
+    // Add TP action
+    _x addAction [format ["Teleport to %1", _name], {
+        cutText [format ["You are being teleported to %1", _this#3#0], "BLACK OUT", 2, true];
+
+        [{
+            player setPos _this;
+
+            [{
+                cutText ["", "BLACK IN", 3, true];
+            }, [], 1] call CFUNC(waitAndExecute);
+        }, _this#3#1, 2] call CFUNC(waitAndExecute);
+    }, [_name, _pos]];
+};
+
+true

--- a/mission_framework/core/reinsertion/functions/fnc_deployRP.sqf
+++ b/mission_framework/core/reinsertion/functions/fnc_deployRP.sqf
@@ -29,18 +29,6 @@ if (GVAR(RPPickUp) && !(isNil {GETVAR((group player),GVAR(RPTent),nil)})) exitWi
     ["Warning", ["The RP is already deployed"]] call BFUNC(showNotification);
 };
 
-/* CURRENTLY DISABLED
-
-// Define squad members
-_unitArray = (units group player) - [player];
-
-// Check if there's any squad member nearby
-if !((_unitArray findIf {(_x distance player < 15) && alive _x}) > -1) exitWith {
-    ["Warning", ["You need one more squad member nearby to be able to deploy a RP"]] call BFUNC(showNotification);
-};
-
-*/
-
 // Check if there's enemy nearby
 if !(allUnits findIf {side _x != civilian && side _x getFriend playerSide < 0.6 && _x distance player < 50} == -1) exitWith {
     ["Warning", ["Cannot deploy a RP when enemies are nearby"]] call BFUNC(showNotification);


### PR DESCRIPTION
 - With this function the mission maker can add more TP destinations to the TP poles.
 - They are synced with JIP players and can be fired via a trigger.
 - It is important to note that it creates a one-way TP destination, just like the already existing ones (RP, MRV etc). 