### PR TITLE
Respawn - Disable respawn during the end screen

### DIFF
--- a/mission_framework/core/end_mission/XEH_PreInit.sqf
+++ b/mission_framework/core/end_mission/XEH_PreInit.sqf
@@ -10,6 +10,7 @@ ADDON = true;
 
 // Init global vars
 GVAR(civilianKills) = [];
+GVAR(outroIsRunning) = false;
 GVAR(deathCount) = 0;
 GVAR(endTitle) = "";
 GVAR(endDescription) = "";

--- a/mission_framework/core/end_mission/functions/fnc_callMission.sqf
+++ b/mission_framework/core/end_mission/functions/fnc_callMission.sqf
@@ -24,7 +24,9 @@ if !(isServer) exitWith {};
 params ["_ending", ["_isVictory", false], ["_side", sideUnknown]];
 
 // Stop the end condition check
-[EGVAR(end_conditions,endConditionCheck)] call CFUNC(removePerFrameHandler);
+if (!isNil QEGVAR(end_conditions,endConditionCheck)) then {
+    [EGVAR(end_conditions,endConditionCheck)] call CFUNC(removePerFrameHandler);
+};
 
 // Set vars
 private _title = [missionConfigfile >> "CfgDebriefing" >> _ending, "title", "UNKNOWN"] call BFUNC(returnConfigEntry);

--- a/mission_framework/core/end_mission/functions/fnc_runOutro.sqf
+++ b/mission_framework/core/end_mission/functions/fnc_runOutro.sqf
@@ -39,8 +39,9 @@ if (hasInterface) then {
     // Screen effects
     [_ending, _isVictory] call FUNC(runClosingShot);
 
-    // Set respawn timer
+    // Set respawn timer and prevent players that just died from entering spectator
     setPlayerRespawnTime 10e10;
+    GVAR(outroIsRunning) = true;
 
     // Disable damage (if setting enabled)
     if (GVAR(disableDamage)) then {

--- a/mission_framework/core/respawn/functions/fnc_eventKilled.sqf
+++ b/mission_framework/core/respawn/functions/fnc_eventKilled.sqf
@@ -80,6 +80,11 @@ if (GVARMAIN(isTvT)) then {
         SETVAR(player,EGVAR(reinsertion,deathPos),getPos player);
 
         if (GETVAR(player,GVAR(tickets),-1) == 0 || (GVARMAIN(moduleWaveRespawn) && EGVAR(respawn_wave,availableWaves) == 0)) then {
+            // Check if the mission is ending
+            if (EGVAR(end_mission,outroIsRunning)) exitWith {
+                setPlayerRespawnTime 10e10;
+            };
+
             // Init spectator screen
             if (GVARMAIN(useACESpectator)) then {
                 [true, true, true] call EFUNC(common,initACESpectator);
@@ -146,6 +151,11 @@ if (GVARMAIN(isTvT)) then {
 
             if !(GVARMAIN(moduleWaveRespawn)) then {
                 setPlayerRespawnTime GVARMAIN(respawnTimer);
+            };
+
+            // Check if the mission is ending
+            if (EGVAR(end_mission,outroIsRunning)) exitWith {
+                setPlayerRespawnTime 10e10;
             };
 
             // Init the complainer mode


### PR DESCRIPTION
**When merged this pull request will:**
- Fix an issue with Terminate mission button in Admin menu when no end condition was active
- Prevent players from entering the spectator screen if they die during the end mission closing shot
- Close #339 