### PR TITLE
End mission - Fix end screen dialog

### DIFF
--- a/mission_framework/core/end_mission/functions/fnc_runClosingShot.sqf
+++ b/mission_framework/core/end_mission/functions/fnc_runClosingShot.sqf
@@ -73,6 +73,12 @@ private _layerEnd = "BIS_fnc_endMission_end" call BFUNC(rscLayer);
                         // Put everyone into spectator channel
                         [player, true] call TFUNC(forceSpectator);
 
+                        // Close any ACE progress bar
+                        uiNamespace setVariable ["ace_common_ctrlProgressBar", controlNull];
+
+                        // Disable input
+                        disableUserInput true;
+
                         // Open dialog
                         createDialog "MF_EndScreen";
 


### PR DESCRIPTION
**When merged this pull request will:**
- Disable user input during the end screen to prevent opening another dialog
- Cancel any ACE progress bars during the end screen
- Close #357 
