### PR TITLE
Admin - Add task icons and force refresh the lists

### DIFF
--- a/mission_framework/core/admin/dialog/MF_AdminMenu.hpp
+++ b/mission_framework/core/admin/dialog/MF_AdminMenu.hpp
@@ -95,8 +95,7 @@ class MF_AdminMenu
             rowHeight = 0;
             sizeEx = (((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 0.8);
             soundSelect[] = {"\A3\ui_f\data\sound\RscListbox\soundSelect",0.09,1.0};
-            colorSelectBackground[] = {0,0,0,0};
-            colorSelectBackground2[] = {0,0,0,0};
+            colorSelectBackground[] = {0.3,0.3,0.3,1};
             shadow = 0;
             class ListScrollBar
             {
@@ -632,15 +631,15 @@ class MF_AdminMenu
             style = 16;
             colorBackground[] = {0.2,0.2,0.2,1};
             colorDisabled[] = {0.2,0.2,0.2,1};
-            colorSelect[] = {0.1294,0.4549,0.6118,1};
+            colorSelect[] = {0.902,0.902,0.902,1};
+            colorSelect2[] = {0.902,0.902,0.902,0.75};
             colorText[] = {0.902,0.902,0.902,1};
             font = "PuristaMedium";
             maxHistoryDelay = 0;
             rowHeight = 0;
             sizeEx = (((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 0.9);
             soundSelect[] = {"\A3\ui_f\data\sound\RscListbox\soundSelect",0.09,1.0};
-            colorSelectBackground[] = {0,0,0,0};
-            colorSelectBackground2[] = {0,0,0,0};
+            colorSelectBackground[] = {0.3,0.3,0.3,1};
             shadow = 0;
             class ListScrollBar
             {

--- a/mission_framework/core/admin/functions/fnc_addPlayerInfoEH.sqf
+++ b/mission_framework/core/admin/functions/fnc_addPlayerInfoEH.sqf
@@ -23,8 +23,8 @@ if !(hasInterface) exitWith {};
 if (isNull findDisplay 799) exitWith {};
 
 ((findDisplay 799) displayCtrl 718) ctrlAddEventHandler ["LBSelChanged", {
-    _text = "";
-
+    private _text = "";
+    
     // Get the currently selected player
     private _player = lbText [718, lbCurSel 718];
 

--- a/mission_framework/core/admin/functions/fnc_setTaskState.sqf
+++ b/mission_framework/core/admin/functions/fnc_setTaskState.sqf
@@ -42,3 +42,5 @@ if (_taskID != "") then {
 
     [COMPONENT_STR, "INFO", "Task state has been updated", true] call EFUNC(main,log);
 };
+
+call FUNC(updateTaskList);

--- a/mission_framework/core/admin/functions/fnc_updatePlayerList.sqf
+++ b/mission_framework/core/admin/functions/fnc_updatePlayerList.sqf
@@ -22,6 +22,9 @@ if !(hasInterface) exitWith {};
 // Exit if the dialog is not visible
 if (isNull findDisplay 799) exitWith {};
 
+// Clear it first
+lbClear 718;
+
 private _playerList = call BFUNC(listPlayers);
 
 _playerList apply {

--- a/mission_framework/core/admin/functions/fnc_updateTaskList.sqf
+++ b/mission_framework/core/admin/functions/fnc_updateTaskList.sqf
@@ -5,7 +5,7 @@
         Malbryn
 
     Description:
-        Updates the progress position in the Admin Menu.
+        Updates the task list in the Admin Menu.
 
     Arguments:
         -
@@ -22,7 +22,13 @@ if !(hasInterface) exitWith {};
 // Exit if the dialog is not visible
 if (isNull findDisplay 799) exitWith {};
 
+disableSerialization;
+
 private _taskList = player call BFUNC(tasksUnit);
+private _ctrl = (findDisplay 799) displayCtrl 712;
+
+// Clear it first
+lbClear 712;
 
 _taskList apply {
     private _task = _x call BFUNC(taskDescription);
@@ -30,19 +36,43 @@ _taskList apply {
 
     private _index = lbAdd [712, _taskName];
 
+    // Get task type icon
+    private _type = _x call BFUNC(taskType);
+    private _typeIcon = getText (configfile >> "CfgTaskTypes" >> _type >> "icon");
+
+    _ctrl lbSetPicture [_index, _typeIcon];
+
+    // Get task state icon
+    private _state = _x call BFUNC(taskState);
+
+    private _stateIcon = switch (_state) do {
+        case "ASSIGNED": {"taskAssigned_ca"};
+        case "SUCCEEDED": {"taskSucceeded_ca"};
+        case "FAILED": {"taskFailed_ca"};
+        case "CANCELED": {"taskCanceled_ca"};
+        default {"taskCreated_ca"};
+    };
+
+    _ctrl lbSetPictureRight [_index, format ["A3\ui_f\data\Map\Diary\Icons\%1.paa", _stateIcon]];
+
     // Task state colour
     private _state = _x call BFUNC(taskState);
-    private _colour = [];
 
-    switch (_state) do {
-        case "ASSIGNED": {_colour = TASKCOLOUR_ASSIGNED};
-        case "SUCCEEDED": {_colour = TASKCOLOUR_SUCCEEDED};
-        case "FAILED": {_colour = TASKCOLOUR_FAILED};
-        case "CANCELED": {_colour = TASKCOLOUR_CANCELLED};
-        default {_colour = TASKCOLOUR_CREATED};
+    private _colour = switch (_state) do {
+        case "ASSIGNED": {TASKCOLOUR_ASSIGNED};
+        case "SUCCEEDED": {TASKCOLOUR_SUCCEEDED};
+        case "FAILED": {TASKCOLOUR_FAILED};
+        case "CANCELED": {TASKCOLOUR_CANCELLED};
+        default {TASKCOLOUR_CREATED};
     };
 
     lbSetColor [712, _index, _colour];
+    lbSetSelectColor [712, _index, _colour];
+
+    _ctrl lbSetPictureColor [_index, _colour];
+    _ctrl lbSetPictureColorSelected [_index, _colour];
+    _ctrl lbSetPictureRightColor [_index, _colour];
+    _ctrl lbSetPictureRightColorSelected [_index, _colour];
 
     // Attach the task ID to the row
     lbSetData [712, _index, _x];

--- a/mission_framework/core/end_mission/functions/fnc_updateTaskList.sqf
+++ b/mission_framework/core/end_mission/functions/fnc_updateTaskList.sqf
@@ -5,7 +5,7 @@
         Malbryn
 
     Description:
-        Updates the progress position in the End Screen.
+        Updates the task list in the End Screen.
 
     Arguments:
         -


### PR DESCRIPTION
**When merged this pull request will:**
- Add icons to the task list
- Make the task list reponsive by refreshing it after changing a list item
- Force update the task & player lists when opening the admin menu 
  - This hopefully fixes #229
- Close #287
