### PR TITLE
Main - Add check for hidden and dynamically simulated units

### DIFF
--- a/mission_framework/core/main/XEH_PREP.hpp
+++ b/mission_framework/core/main/XEH_PREP.hpp
@@ -1,4 +1,5 @@
 PREP(addCredits);
+PREP(checkUnits);
 PREP(initCustomEHs);
 PREP(log);
 PREP(writeRPT);

--- a/mission_framework/core/main/XEH_PostInitServer.sqf
+++ b/mission_framework/core/main/XEH_PostInitServer.sqf
@@ -2,3 +2,6 @@
 
 // Set time multiplier
 setTimeMultiplier GVARMAIN(timeAcceleration);
+
+// Unit check
+call FUNC(checkUnits);

--- a/mission_framework/core/main/functions/fnc_checkUnits.sqf
+++ b/mission_framework/core/main/functions/fnc_checkUnits.sqf
@@ -1,0 +1,34 @@
+#include "script_component.hpp"
+
+/*
+    Author:
+        Malbryn
+
+    Description:
+        Checks every AI unit to see if they are hidden while having dynamic simulation enabled.
+        See issue: https://github.com/Malbryn/MalFramework/issues/383
+        Works in debug mode only.
+
+    Arguments:
+        -
+
+    Example:
+        call MF_main_fnc_checkUnits
+
+    Returns:
+        void
+*/
+
+if !(isServer && GVARMAIN(debugMode)) exitWith {};
+
+private _hiddenUnits = [];
+
+{
+    if (isObjectHidden _x && (dynamicSimulationEnabled _x || dynamicSimulationEnabled (group _x))) then {
+        _hiddenUnits pushBack _x;
+    };
+} forEach allUnits;
+
+if (count _hiddenUnits != 0) then {
+    [COMPONENT_STR, "WARNING", format ["The following units are hidden and have dynamic simulation enabled: %1", _hiddenUnits], true, 0] call FUNC(log);
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Add an automatic check that makes sure no AI unit is hidden and has dynamic simulation enabled (see issue #383)
- Close #383 
