### PR TITLE
Respawn - Disconnect player's UAV terminal if the player dies

### DIFF
--- a/mission_framework/core/respawn/functions/fnc_eventKilled.sqf
+++ b/mission_framework/core/respawn/functions/fnc_eventKilled.sqf
@@ -39,6 +39,11 @@ if (isPlayer _killer && {(side _killer) == playerSide}) then {
     [QEGVAR(admin,logFF), [name _unit, name _killer]] call CFUNC(globalEvent);
 };
 
+// Disconnect connected UAV's
+if (!isNull getConnectedUAV _unit) then {
+    _unit connectTerminalToUAV objNull;
+};
+
 // Screen effects
 "dynamicBlur" ppEffectEnable true;
 "dynamicBlur" ppEffectAdjust [0];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix an issue with UAV's becoming unavailable if the connected player dies
- Close #239 
